### PR TITLE
Updated g:semanticEnableFileTypes usage to allow for CursorHold autocmd 

### DIFF
--- a/doc/semantic-highlight.txt
+++ b/doc/semantic-highlight.txt
@@ -51,5 +51,26 @@ provide an override object as below:
 
 let g:semanticBlacklistOverride = { 'javascript': ['this', 'that', 'the_other'] }
 
+g:semanticEnableFileTypes                                           *g:semanticEnableFileTypes*
+
+The plugin can be configured to activate automatically for certain filetypes.
+
+There are three possible behaviours, off, filetype only and filetype +
+cursorhold.
+
+filetype:
+
+This will automatically start the plugin when entering a file of the given
+filetypes.
+
+let g:semanticEnableFileTypes = ['javascript', 'vim']
+
+filetype + cursorhold:
+
+This will automatically start the plugin when entering a file of the given
+filetypes, and re-render on cursorhold for the same filetypes.
+
+let g:semanticEnableFileTypes = { 'javascript': 'js', 'vim': 'vim' }
+
 vim:tw=78:ts=8:ft=help:norl:
 

--- a/plugin/semhl.vim
+++ b/plugin/semhl.vim
@@ -5,7 +5,12 @@
 
 " Allow users to configure the plugin to auto start for certain filetypes
 if (exists('g:semanticEnableFileTypes'))
-	execute 'autocmd FileType ' . join(g:semanticEnableFileTypes, ',') . ' call s:enableHighlight()'
+	if type(g:semanticEnableFileTypes) == type([])
+		execute 'autocmd FileType ' . join(g:semanticEnableFileTypes, ',') . ' call s:enableHighlight()'
+	elseif type(g:semanticEnableFileTypes) == type({})
+		execute 'autocmd FileType ' . join(keys(g:semanticEnableFileTypes), ',') . ' call s:enableHighlight()'
+		execute 'autocmd CursorHold ' . join(map(values(g:semanticEnableFileTypes), '"*." . v:val'), ',') . ' call s:semHighlight()'
+	endif
 endif
 
 " Set defaults for colors


### PR DESCRIPTION
Added option to provide dictionary for g:semanticEnableFileTypes, in which case a CusorHold autocmd can be applied in addition to the FileType autocmd