### PR TITLE
Add support ZyX's guicolors option

### DIFF
--- a/plugin/semhl.vim
+++ b/plugin/semhl.vim
@@ -130,7 +130,7 @@ function! s:buildColors()
 	else
 		let type = 'fg'
 	endif
-	if has('gui_running')
+	if has('gui_running') || (exists('&guicolors') && &guicolors)
 		let colorType = 'gui'
 		" Update color list in case the user made any changes
 		let s:semanticColors = g:semanticGUIColors


### PR DESCRIPTION
ZyX have a Vim fork support true color in Terminal [ref](https://bitbucket.org/ZyX_I/vim)
This PR detect this feature and enable gui color if it is available.