### PR TITLE
Don't duplcated define syntax

### DIFF
--- a/plugin/semhl.vim
+++ b/plugin/semhl.vim
@@ -63,6 +63,7 @@ function! s:readCache() abort
 endfunction
 
 let s:cache = {}
+let s:cache_defined = {}
 if g:semanticPersistCache && filereadable(g:semanticPersistCacheLocation)
 	let s:cache = s:readCache()
 endif
@@ -113,7 +114,8 @@ function! s:semHighlight()
 			endif
 
 			let l:no_blacklist_exists_for_filetype = empty(s:blacklist) || !has_key(s:blacklist, &filetype)
-			if (l:no_blacklist_exists_for_filetype || index(s:blacklist[&filetype], match) == -1)
+			if ((l:no_blacklist_exists_for_filetype || index(s:blacklist[&filetype], match) == -1) && !has_key(s:cache_defined, match))
+        let s:cache_defined[match] = 1
 				execute 'syn keyword _semantic' . s:getCachedColor(cur_color, match) . " containedin=phpBracketInString,phpVarSelector,phpClExpressions,phpIdentifier " . match
 				let cur_color = (cur_color + 1) % colorLen
 			endif

--- a/plugin/semhl.vim
+++ b/plugin/semhl.vim
@@ -63,7 +63,7 @@ function! s:readCache() abort
 endfunction
 
 let s:cache = {}
-let s:cache_defined = {}
+let b:cache_defined = {}
 if g:semanticPersistCache && filereadable(g:semanticPersistCacheLocation)
 	let s:cache = s:readCache()
 endif
@@ -114,8 +114,8 @@ function! s:semHighlight()
 			endif
 
 			let l:no_blacklist_exists_for_filetype = empty(s:blacklist) || !has_key(s:blacklist, &filetype)
-			if ((l:no_blacklist_exists_for_filetype || index(s:blacklist[&filetype], match) == -1) && !has_key(s:cache_defined, match))
-        let s:cache_defined[match] = 1
+			if ((l:no_blacklist_exists_for_filetype || index(s:blacklist[&filetype], match) == -1) && !has_key(b:cache_defined, match))
+        let b:cache_defined[match] = 1
 				execute 'syn keyword _semantic' . s:getCachedColor(cur_color, match) . " containedin=phpBracketInString,phpVarSelector,phpClExpressions,phpIdentifier " . match
 				let cur_color = (cur_color + 1) % colorLen
 			endif
@@ -155,6 +155,7 @@ function! s:disableHighlight()
 	for key in range(len(s:semanticColors))
 		execute 'syn clear _semantic'.key
 	endfor
+  let b:cache_defined = {}
 endfunction
 
 function! s:enableHighlight()


### PR DESCRIPTION
Current implement will define syntax multiple times.
Add an runtime cache to memorize.

Before: 
![2015-04-14 9 55 41](https://cloud.githubusercontent.com/assets/16474/7138181/3216b8bc-e2f1-11e4-8d79-6d8282606407.png)

After:
![2015-04-14 9 55 20](https://cloud.githubusercontent.com/assets/16474/7138185/3e2e8a8a-e2f1-11e4-946b-9142da6ab8f3.png)

