### PR TITLE
match instead of keyword

### DIFF
--- a/plugin/semhl.vim
+++ b/plugin/semhl.vim
@@ -124,8 +124,7 @@ function! s:semHighlight()
 				if (!empty(s:containedinlist) && has_key(s:containedinlist, &filetype))
 					let l:containedin = ' containedin=' . s:containedinlist[&filetype]
 				endif
-
-				execute 'syn keyword _semantic' . s:getCachedColor(cur_color, match) . l:containedin . ' ' . match
+				execute 'syn match _semantic' . s:getCachedColor(cur_color, match) . l:containedin . ' "\<[\$]*' . match . '\>"'
 				let cur_color = (cur_color + 1) % colorLen
 			endif
 


### PR DESCRIPTION
`syn keyword` is a pain to deal with when you want to do something like this:
```
syn match cppClass "\([a-zA-Z0-9_]*::\)\+" conceal
```
since keyword takes precedence and stops vim from concealing things like `boost::asio::`. However `syn match` can be overridden and doesn't have that problem.

Please tell me if there's a way to deal with this w/o changing keyword to match but so far it seems to me that's the only way.