### PR TITLE
Added support to light backgrounds and to the Oni editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ let g:semanticTermColors = [28,1,2,3,4,5,6,7,25,9,10,34,12,13,14,15,16,125,124,1
 
 Either list can also be set in your vimrc
 
+#### N.B. This forked version of SemanticHighlight computes a measure of darkness by using the HSP model and then rotate all the default colors to make them comfortable on light backgrounds if `darkness < 0.5`. I plan to come back later to dinamically change colors based on this measure (no more thresholds). 
+
 ## Language support
 
 This plugin is language agnostic, meaning it will work on any language with words. However, some languages have been tweaked by default to disable highlighting of language keywords.
@@ -100,4 +102,8 @@ Also big thanks to everyone who submitted bugs, suggestions, and pull requests!
 ## About me
 
 This plugin has been forked from jaxbot's [SemanticHighlight](https://github.com/jaxbot/semantic-highlight.vim) to add the support to light backgrounds and to the [Oni](https://github.com/onivim/oni) editor.
+
+This version has:
+* automatic change colors to be comfortable with light backgrounds
+* compatible with Oni edito - in future this should be compatible with any Nvim gui
 

--- a/README.md
+++ b/README.md
@@ -99,5 +99,5 @@ Also big thanks to everyone who submitted bugs, suggestions, and pull requests!
 
 ## About me
 
-I'm Jonathan. I like to hack around with Vim, Node.js, embedded hardware, and Glass. If any of that sounds interesting, [follow me!](https://github.com/jaxbot)
+This plugin has been forked from jaxbot's [SemanticHighlight](https://github.com/jaxbot/semantic-highlight.vim) to add the support to light backgrounds and to the [Oni](https://github.com/onivim/oni) editor.
 

--- a/README.md
+++ b/README.md
@@ -105,5 +105,5 @@ This plugin has been forked from jaxbot's [SemanticHighlight](https://github.com
 
 This version has:
 * automatic change colors to be comfortable with light backgrounds
-* compatible with Oni edito - in future this should be compatible with any Nvim gui
+* compatible with Oni editor - in future this should be compatible with any Nvim gui
 

--- a/plugin/semhl.vim
+++ b/plugin/semhl.vim
@@ -13,13 +13,10 @@ if (exists('g:semanticEnableFileTypes'))
 	endif
 endif
 
-" Set defaults for colors
-let s:semanticGUIColors = ["#9CD8F7", "#F5FA1D", "#F97C65", "#35D27F", "#EB75D6", "#E5D180", "#8997F5", "#D49DA5", "#7FEC35", "#F6B223", "#B4F1C3", "#99B730", "#F67C1B", "#3AC6BE", "#EAAFF1", "#DE9A4E", "#BBEA87", "#EEF06D", "#8FB272", "#EAA481", "#F58AAE", "#80B09B", "#5DE866", "#B5A5C5", "#88ADE6", "#4DAABD", "#EDD528", "#FA6BB2", "#47F2D4", "#F47F86", "#2ED8FF", "#B8E01C", "#C5A127", "#74BB46", "#D386F1", "#97DFD6", "#B1A96F", "#66BB75", "#97AA49", "#EF874A", "#48EDF0", "#C0AE50", "#89AAB6", "#D7D1EB", "#5EB894", "#57F0AC", "#B5AF1B", "#B7A5F0", "#8BE289", "#D38AC6", "#C8EE63", "#ED9C36", "#85BA5F", "#9DEA74", "#85C52D", "#40B7E5", "#EEA3C2", "#7CE9B6", "#8CEC58", "#D8A66C", "#51C03B", "#C4CE64", "#45E648", "#4DC15E", "#63A5F3", "#EA8C66", "#D2D43E", "#E5BCE8", "#E4B7CB", "#B092F4", "#44C58C", "#D1E998", "#76E4F2", "#E19392", "#A8E5A4", "#BF9FD6", "#E8C25B", "#58F596", "#6BAEAC", "#94C291", "#7EF1DB", "#E8D65C", "#A7EA38", "#D38AE0", "#ECF453", "#5CD8B8", "#B6BF6B", "#BEE1F1", "#B1D43E", "#EBE77B", "#84A5CD", "#CFEF7A", "#A3C557", "#E4BB34", "#ECB151", "#BDC9F2", "#5EB0E9", "#E09764", "#9BE3C8", "#B3ADDC", "#B2AC36", "#C8CD4F", "#C797AF", "#DCDB26", "#BCA85E", "#E495A5", "#F37DB8", "#70C0B1", "#5AED7D", "#E49482", "#8AA1F0", "#B3EDEE", "#DAEE34", "#EBD646", "#ECA2D2", "#A0A7E6", "#3EBFD3", "#C098BF", "#F1882E", "#77BFDF", "#7FBFC7", "#D4951F", "#A5C0D0", "#B892DE", "#F8CB31", "#75D0D9", "#A6A0B4", "#EA98E4", "#F38BE6", "#DC83A4"]
 let s:semanticTermColors = range(20)
 
 " The user can change the GUI/Term colors, but cannot directly access the list of colors we use
-" If the user overrode the default in their vimrc, use that
-let g:semanticGUIColors = exists('g:semanticGUIColors') ? g:semanticGUIColors : s:semanticGUIColors
+" If the user override the default in their vimrc, use that
 let g:semanticTermColors = exists('g:semanticTermColors') ? g:semanticTermColors : s:semanticTermColors
 
 " Allow the user to turn cache off
@@ -141,9 +138,10 @@ function! s:buildColors()
 	else
 		let type = 'fg'
 	endif
-	if $NVIM_TUI_ENABLE_TRUE_COLOR || has('gui_running') || (exists('&guicolors') && &guicolors)
+	if $NVIM_TUI_ENABLE_TRUE_COLOR || has('gui_running') || (exists('&guicolors') && &guicolors) || exists('g:gui_oni')
 		let colorType = 'gui'
 		" Update color list in case the user made any changes
+        call s:buildGUIColors()
 		let s:semanticColors = g:semanticGUIColors
 	else
 		let colorType = 'cterm'
@@ -183,3 +181,23 @@ function! s:toggleHighlight()
 	endif
 endfunction
 
+function! s:buildGUIColors()
+    " Taking background color
+    let hex_color = synIDattr(hlID("Normal"), "bg") " hex value starting with `#`
+    let hex_color = strpart(hex_color, 1) " skipping the first `#`
+    let hex_color = str2nr(hex_color, 16) " converting to decimal 
+    " now converting to RGB
+    let r = hex_color / 65536
+    let g = (hex_color - r * 65536) / 256
+    let b = hex_color - r * 65536 - g * 256
+    " Taking a measure of darkness through HSP model
+    let darkness = 1 - ( 0.299*pow(r, 2) + 0.587*pow(g, 2) + 0.114*pow(b, 2) ) / 65536
+
+    " Set defaults for colors
+    if darkness > 0.5
+        let s:semanticGUIColors = ["#9CD8F7", "#F5FA1D", "#F97C65", "#35D27F", "#EB75D6", "#E5D180", "#8997F5", "#D49DA5", "#7FEC35", "#F6B223", "#B4F1C3", "#99B730", "#F67C1B", "#3AC6BE", "#EAAFF1", "#DE9A4E", "#BBEA87", "#EEF06D", "#8FB272", "#EAA481", "#F58AAE", "#80B09B", "#5DE866", "#B5A5C5", "#88ADE6", "#4DAABD", "#EDD528", "#FA6BB2", "#47F2D4", "#F47F86", "#2ED8FF", "#B8E01C", "#C5A127", "#74BB46", "#D386F1", "#97DFD6", "#B1A96F", "#66BB75", "#97AA49", "#EF874A", "#48EDF0", "#C0AE50", "#89AAB6", "#D7D1EB", "#5EB894", "#57F0AC", "#B5AF1B", "#B7A5F0", "#8BE289", "#D38AC6", "#C8EE63", "#ED9C36", "#85BA5F", "#9DEA74", "#85C52D", "#40B7E5", "#EEA3C2", "#7CE9B6", "#8CEC58", "#D8A66C", "#51C03B", "#C4CE64", "#45E648", "#4DC15E", "#63A5F3", "#EA8C66", "#D2D43E", "#E5BCE8", "#E4B7CB", "#B092F4", "#44C58C", "#D1E998", "#76E4F2", "#E19392", "#A8E5A4", "#BF9FD6", "#E8C25B", "#58F596", "#6BAEAC", "#94C291", "#7EF1DB", "#E8D65C", "#A7EA38", "#D38AE0", "#ECF453", "#5CD8B8", "#B6BF6B", "#BEE1F1", "#B1D43E", "#EBE77B", "#84A5CD", "#CFEF7A", "#A3C557", "#E4BB34", "#ECB151", "#BDC9F2", "#5EB0E9", "#E09764", "#9BE3C8", "#B3ADDC", "#B2AC36", "#C8CD4F", "#C797AF", "#DCDB26", "#BCA85E", "#E495A5", "#F37DB8", "#70C0B1", "#5AED7D", "#E49482", "#8AA1F0", "#B3EDEE", "#DAEE34", "#EBD646", "#ECA2D2", "#A0A7E6", "#3EBFD3", "#C098BF", "#F1882E", "#77BFDF", "#7FBFC7", "#D4951F", "#A5C0D0", "#B892DE", "#F8CB31", "#75D0D9", "#A6A0B4", "#EA98E4", "#F38BE6", "#DC83A4"]
+    else
+        let s:semanticGUIColors = ['#632708', '#0A05E2', '#06839A', '#CA2D80', '#148A29', '#1A2E7F', '#76680A', '#2B625A', '#8013CA', '#094DDC', '#4B0E3C', '#6648CF', '#0983E4', '#C53941', '#15500E', '#2165B1', '#441578', '#110F92', '#704D8D', '#155B7E', '#0A7551', '#7F4F64', '#A21799', '#4A5A3A', '#775219', '#B25542', '#122AD7', '#05944D', '#B80D2B', '#0B8079', '#D12700', '#471FE3', '#3A5ED8', '#8B44B9', '#2C790E', '#682029', '#4E5690', '#99448A', '#6855B6', '#1078B5', '#B7120F', '#3F51AF', '#765549', '#282E14', '#A1476B', '#A80F53', '#4A50E4', '#485A0F', '#741D76', '#2C7539', '#37119C', '#1263C9', '#7A45A0', '#62158B', '#7A3AD2', '#BF481A', '#115C3D', '#831649', '#7313A7', '#275993', '#AE3FC4', '#3B319B', '#BA19B7', '#B23EA1', '#9C5A0C', '#157399', '#2D2BC1', '#1A4317', '#1B4834', '#4F6D0B', '#BB3A73', '#2E1667', '#891B0D', '#1E6C6D', '#571A5B', '#406029', '#173DA4', '#A70A69', '#945153', '#6B3D6E', '#810E24', '#1729A3', '#5815C7', '#2C751F', '#130BAC', '#A32747', '#494094', '#411E0E', '#4E2BC1', '#141884', '#7B5A32', '#301085', '#5C3AA8', '#1B44CB', '#134EAE', '#42360D', '#A14F16', '#1F689B', '#641C37', '#4C5223', '#4D53C9', '#3732B0', '#386850', '#2324D9', '#4357A1', '#1B6A5A', '#0C8247', '#8F3F4E', '#A51282', '#1B6B7D', '#755E0F', '#4C1211', '#2511CB', '#1429B9', '#135D2D', '#5F5819', '#C1402C', '#3F6740', '#0E77D1', '#884020', '#804038', '#2B6AE0', '#5A3F2F', '#476D21', '#0734CE', '#8A2F26', '#595F4B', '#15671B', '#0C7419', '#237C5B']
+    endif
+    let g:semanticGUIColors = exists('g:semanticGUIColors') ? g:semanticGUIColors : s:semanticGUIColors
+endfunction


### PR DESCRIPTION
I plan to:
* add support to any background by dynamically change all colors based on a darkness measure. In this pull request, the darkness measure is used to chose between only 2 set of colors
* add support to any neovim GUI (reference: https://github.com/onivim/oni/issues/2552)